### PR TITLE
Feature/improve performance

### DIFF
--- a/pgdatadiff/main.py
+++ b/pgdatadiff/main.py
@@ -1,6 +1,6 @@
 """
 Usage:
-  pgdatadiff --firstdb=<firstconnectionstring> --seconddb=<secondconnectionstring> [--only-data|--only-sequences] [--count-only] [--chunk-size=<size>]
+  pgdatadiff --firstdb=<firstconnectionstring> --seconddb=<secondconnectionstring> [--only-data|--only-sequences] [--count-only] [--chunk-size=<size>] [--check-columns=<column> ...]
   pgdatadiff --version
 
 Options:
@@ -12,6 +12,7 @@ Options:
   --only-sequences   Only compare seqences, exclude data
   --count-only       Do a quick test based on counts alone
   --chunk-size=10000       The chunk size when comparing data [default: 10000]
+  --check-columns=column-name    Restrict check to given columns, repeatable. Primary key is always checked.
 """
 
 import pkg_resources
@@ -34,7 +35,9 @@ def main():
 
     differ = DBDiff(first_db_connection_string, second_db_connection_string,
                     chunk_size=arguments['--chunk-size'],
-                    count_only=arguments['--count-only'])
+                    count_only=arguments['--count-only'],
+                    check_columns=arguments['--check-columns']
+                    )
 
     if not arguments['--only-sequences']:
         if differ.diff_all_table_data():

--- a/pgdatadiff/main.py
+++ b/pgdatadiff/main.py
@@ -22,6 +22,7 @@ from docopt import docopt
 
 
 def main():
+    print(red("Using custom pgatadiff"))
     arguments = docopt(
         __doc__, version=pkg_resources.require("pgdatadiff")[0].version)
     first_db_connection_string=arguments['--firstdb']

--- a/pgdatadiff/main.py
+++ b/pgdatadiff/main.py
@@ -12,7 +12,7 @@ Options:
   --only-sequences   Only compare seqences, exclude data
   --count-only       Do a quick test based on counts alone
   --chunk-size=10000       The chunk size when comparing data [default: 10000]
-  --check-columns=column-name    Restrict check to given columns, repeatable. Primary key is always checked.
+  --check-columns=column-name    Restrict check to given columns. Repeat to add multiple columns. Primary key is always checked.
 """
 
 import pkg_resources

--- a/pgdatadiff/pgdatadiff.py
+++ b/pgdatadiff/pgdatadiff.py
@@ -57,34 +57,58 @@ class DBDiff(object):
         except NoSuchTableError:
             return False, "table is missing"
 
+        SQL_QUERY_FIRST_PK = f"""
+            SELECT {pk} FROM {tablename} ORDER BY {pk} LIMIT 1;
+        """
+        prev_cursor = None
+        cursor = self.firstsession.execute(SQL_QUERY_FIRST_PK).scalar()
+
+        if cursor != self.secondsession.execute(SQL_QUERY_FIRST_PK).scalar():
+            return False, "first primary keys are different"
+
+
+        SQL_QUERY_CURSOR = f"""
+        SELECT {pk} FROM(
+            SELECT {pk}
+            FROM {tablename}
+            WHERE {pk} >= :cursor
+            ORDER BY {pk} ASC
+            LIMIT :row_limit) s
+        ORDER BY {pk} DESC
+        LIMIT 1;
+        """
+
         SQL_TEMPLATE_HASH = f"""
         SELECT md5(array_agg(md5((t.*)::varchar))::varchar)
         FROM (
                 SELECT *
                 FROM {tablename}
-                ORDER BY {pk} limit :row_limit offset :row_offset
+                WHERE {pk} >= :cursor
+                ORDER BY {pk} ASC
+                limit :row_limit
             ) AS t;
-                        """
-
-        position = 0
-
-        while position <= firstquery.count():
+        """
+        while prev_cursor != cursor:
             firstresult = self.firstsession.execute(
                 SQL_TEMPLATE_HASH,
                 {"row_limit": self.chunk_size,
-                 "row_offset": position}).fetchone()
+                 "cursor": cursor}).scalar()
             secondresult = self.secondsession.execute(
                 SQL_TEMPLATE_HASH,
                 {"row_limit": self.chunk_size,
-                 "row_offset": position}).fetchone()
+                 "cursor": cursor}).scalar()
             if firstresult != secondresult:
-                return False, f"data is different - position {position} -" \
-                              f" {position + self.chunk_size}"
-            position += self.chunk_size
+                return False, f"data is different - start_cursor {cursor} -" \
+                              f" with {self.chunk_size}"
+            prev_cursor = cursor
+            cursor = self.firstsession.execute(
+               SQL_QUERY_CURSOR,
+               {"row_limit": self.chunk_size,
+                "cursor": cursor}).scalar()
         return True, "data is identical."
 
     def get_all_sequences(self):
-        GET_SEQUENCES_SQL = """SELECT c.relname FROM 
+        GET_SEQUENCES_SQL = """SELECT c.relname FROM
         pg_class c WHERE c.relkind = 'S';"""
         return [x[0] for x in
                 self.firstsession.execute(GET_SEQUENCES_SQL).fetchall()]


### PR DESCRIPTION
Replace use of offset with `WHERE ... ORDER BY` on primary key. On one of our database with millions of large rows, this improved performance by more than 4(went from 2h+ to 30 minutes).
See https://use-the-index-luke.com/sql/partial-results/fetch-next-page

Add --check-columns option to restrict columns to check for equality, this did not improve performance in our case but can still be useful.